### PR TITLE
add more info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ I think I have something which ticks these boxes? Just trying to figure out some
 
 This will build the codebase for these different targets and output the results in `/dist`.
 
+This requires a recent version of node 12 or higher.  Older versions of node 12 will not work.
+
 ## Orientation
 
 ### Source
 
 `src` contains four different entrypoints:
 
-- index.js
-- index.browser.js
-- index.node.js
-- index.deno.js
+- index.ts
+- index.browser.ts
+- index.node.ts
+- index.deno.ts
 
-All of these entrypoints export a function called `time`, defined in `src/time.js`. I put this here because reusing code across all these different versions is a hard requirement.
+All of these entrypoints export a function called `time`, defined in `src/time.ts`. I put this here because reusing code across all these different versions is a hard requirement.
 
 This file uses an external dependency, which we'll come back to later.
 
@@ -47,5 +49,82 @@ There's also a http plugin I nabbed from the esbuild docs which is not really ne
 - `poly.browser.js`: This can be used with a script tag in a browser with the `type="module"`. The external dependency is resolved as a remote URL (e.g. `https://cdn.skypack.dev/dot-beat-time`)
 - `poly.esm.js`: An ESM version of the module with external dependencies referred to by local name (e.g. `dot-beat-time`)
 - `poly.deno.js`: This can be used in Deno. Local imports have been transformed to URL imports.
-- `poly.node.js`: This is used by Node when imported using `import`.
-- `poly.node.cjs.js`: This is used by Node when imported using `require`.
+- `poly.node.mjs`: This is used by Node when imported using `import`.
+- `poly.node.cjs`: This is used by Node when imported using `require`.
+
+### Comparing the outputs
+
+#### `poly.browser.bundled.js`
+
+* 3rd party dependencies: bundled
+* Local dependencies: inlined
+* Container: IIFE, making a global `Poly` for accessing it from other browser scripts
+* Index file used: `index.browser.ts`
+* To use it from HTML:
+```html
+    <script src="/dist/poly.browser.bundled.js"></script>
+    <script>Poly.time()</script>
+```
+
+#### `poly.browser.js`
+
+* 3rd party dependencies: bundled (TODO: should be using skypack URLs instead?)
+* Local dependencies: inlined
+* Container: ESM `export`
+* Index file used: `index.browser.ts`
+* To use it from HTML:
+```html
+    <script src="/dist/poly.browser.js" type="module"></script>
+    <script>
+        import {time} from '/dist/poly.browser.js'
+        time();
+    </script>
+```
+
+#### `poly.deno.js`
+
+* 3rd party dependencies: bundled (TODO: should be using skypack URLs instead?)
+* Local dependencies: inlined
+* Container: ESM `export`
+* Index file used: `index.deno.ts`
+* To use it from a Deno script:
+```js
+    import { time } from 'poly';
+    poly.time();
+```
+
+#### `poly.esm.js`
+
+* 3rd party dependencies: `import { now } from 'dot-beat-time'`
+* Local dependencies: inlined
+* Container: ESM `export`
+* Index file used: `index.browser.ts`
+* To use it from... TODO: what context is this used from?
+```js
+    import { time } from 'poly';
+    poly.time();
+```
+
+#### `poly.node.cjs`
+
+* 3rd party dependencies: `require('dot-beat-time')`
+* Local dependencies: inlined
+* Container: CJS `module.exports = {...}`
+* Index file used: `index.node.ts`
+* To use it from a node script:
+```js
+    let poly = require('poly');
+    poly.time();
+```
+
+#### `poly.node.mjs`
+
+* 3rd party dependencies: `import { now } from 'dot-beat-time'`
+* Local dependencies: inlined
+* Container: ESM `export`
+* Index file used: `index.node.ts`
+* To use it from a node script:
+```js
+    import { time } from 'poly';
+    poly.time();
+```


### PR DESCRIPTION
* Updated `js` to `ts`
* Dug into the output `dist/` files and wrote comparisons of each one.
* TODO: no skypack URLs are being output, instead the external modules are being bundled.  This doesn't match the README, is the README out of date or should it be producing skypack URLs? 
* I'm not certain the usage examples are correct except for the browser ones